### PR TITLE
Host sweetconverting on owned domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+www.sweetconverting.online

--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
     <head>
         <link rel="stylesheet" href="main.css">
         <meta charset="UTF-8">
-        <meta http-equic="X-UA-Compatible" content="IE=edge">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Sweet Converting </title>
+        <title>Sweet Converting</title>
         <style>
             body {
                 margin: 0;
@@ -39,7 +39,8 @@
         <script type="importmap">
             {
                 "imports": {
-                    "three": "./three.js-master/three.js-master/build/three.module.js"
+                    "three": "https://unpkg.com/three@0.158.0/build/three.module.js",
+                    "three/addons/": "https://unpkg.com/three@0.158.0/examples/jsm/"
                 }
             }
         </script>

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-import * as THREE from './three.js-master/three.js-master/build/three.module.js'
-import {GLTFLoader} from './three.js-master/three.js-master/examples/jsm/loaders/GLTFLoader.js'
-import {STLLoader} from './three.js-master/three.js-master/examples/jsm/loaders/STLLoader.js'
-import {OrbitControls} from './three.js-master/three.js-master/examples/jsm/controls/OrbitControls.js'
+import * as THREE from 'three'
+import {GLTFLoader} from 'three/addons/loaders/GLTFLoader.js'
+import {STLLoader} from 'three/addons/loaders/STLLoader.js'
+import {OrbitControls} from 'three/addons/controls/OrbitControls.js'
 
 
 const canvas = document.querySelector('canvas.webgl')
@@ -161,7 +161,7 @@ function animate(){
 
 function onWindowResize() {
     camera.aspect = window.innerWidth/window.innerHeight
-    camera.updateProjectionMatric()
+    camera.updateProjectionMatrix()
     renderer.setSize(window.innerWidth, window.innerHeight)
 }
 


### PR DESCRIPTION
Configure GitHub Pages for `www.sweetconverting.online`, migrate Three.js to CDN, and fix minor code issues for improved performance and reliability.

---
<a href="https://cursor.com/background-agent?bcId=bc-f2c2d754-1b51-4d71-acf7-1b64ddf5d66a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f2c2d754-1b51-4d71-acf7-1b64ddf5d66a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>

┆Issue is synchronized with this [Notion page](https://www.notion.so/1-Host-sweetconverting-on-owned-domain-261e0d23ae3481cab451fde5283fa3e0) by [Unito](https://www.unito.io)
