### PR TITLE
Fix model loading after clearing models

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,10 +127,7 @@ stlFileInput.addEventListener('change', loadSTLFile)
 
 //Clear Any kind of models in the Viewer
 function clearModels(){
-    while (viewerContainer.firstChild){
-        viewerContainer.firstChild.remove()
-    }
-
+    // Remove models from the scene but keep the renderer's DOM element
     for (let i = 0; i < models.length; i++) {
         scene.remove(models[i])
     }


### PR DESCRIPTION
Prevent canvas from becoming white and blocking subsequent model loads by no longer removing the renderer's DOM element when clearing models.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2b76168-9149-4cd3-92fd-e8179b6c1460">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d2b76168-9149-4cd3-92fd-e8179b6c1460">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>

┆Issue is synchronized with this [Notion page](https://www.notion.so/4-Fix-model-loading-after-clearing-models-261e0d23ae3481cea5a7c3d2643e084c) by [Unito](https://www.unito.io)
