### PR TITLE
Consolidate model loading and filter file types

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,12 +23,8 @@
             </div>
             <div id="button-container">
                 <div>
-                    <input type="file" id="glb-file-input" accept=".glb" style="display: none" />
-                    <button class="custom-button" id="glb-load-button">Load GLB</button>
-                </div>
-                <div>
-                    <input type="file" id="stl-file-input" accept=".stl" style="display: none" />
-                    <button class="custom-button" id="stl-load-button">Load STL</button>
+                    <input type="file" id="model-file-input" accept=".glb,.stl" style="display: none" />
+                    <button class="custom-button" id="model-load-button">Load model</button>
                 </div>
                 <div>
                     <button class="custom-button" id="clear-models">Clear models</button>

--- a/index.js
+++ b/index.js
@@ -62,16 +62,6 @@ function loadGLBFile(event) {
     reader.readAsArrayBuffer(file)
   }
 
-//Load a GLB file in the Viewer
-const glbLoadButton = document.getElementById('glb-load-button')
-glbLoadButton.addEventListener('click', function () {
-    const glbFileInput = document.getElementById('glb-file-input')
-    glbFileInput.click()
-});
-
-const glbFileInput = document.getElementById('glb-file-input')
-glbFileInput.addEventListener('change', loadGLBFile)
-
 //STL Loader
 function loadSTLFile(event) {
     const file = event.target.files[0];
@@ -115,15 +105,32 @@ function loadSTLFile(event) {
     reader.readAsArrayBuffer(file)
   }
 
-//Load a STL file in the Viewer
-const stlLoadButton = document.getElementById('stl-load-button')
-stlLoadButton.addEventListener('click', function () {
-    const stlFileInput = document.getElementById('stl-file-input')
-    stlFileInput.click()
+//Unified model loader - detects file type and calls appropriate loader
+function loadModelFile(event) {
+    const file = event.target.files[0];
+    if (!file) return;
+    
+    const fileName = file.name.toLowerCase();
+    
+    if (fileName.endsWith('.glb')) {
+        loadGLBFile(event);
+    } else if (fileName.endsWith('.stl')) {
+        loadSTLFile(event);
+    } else {
+        console.error('Unsupported file type. Please select a GLB or STL file.');
+        alert('Unsupported file type. Please select a GLB or STL file.');
+    }
+}
+
+//Load a model file in the Viewer
+const modelLoadButton = document.getElementById('model-load-button')
+modelLoadButton.addEventListener('click', function () {
+    const modelFileInput = document.getElementById('model-file-input')
+    modelFileInput.click()
 });
 
-const stlFileInput = document.getElementById('stl-file-input')
-stlFileInput.addEventListener('change', loadSTLFile)
+const modelFileInput = document.getElementById('model-file-input')
+modelFileInput.addEventListener('change', loadModelFile)
 
 //Clear Any kind of models in the Viewer
 function clearModels(){


### PR DESCRIPTION
Merge "Load GLB" and "Load STL" buttons into a single "Load model" button to simplify model loading and file type selection.

---
<a href="https://cursor.com/background-agent?bcId=bc-df3a02dc-d260-4a9d-90cb-d744f18b3093">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-df3a02dc-d260-4a9d-90cb-d744f18b3093">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>

┆Issue is synchronized with this [Notion page](https://www.notion.so/5-Consolidate-model-loading-and-filter-file-types-261e0d23ae34817bb802f1e53c90b87f) by [Unito](https://www.unito.io)
