### PR TITLE
Add file type support label

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
             </div>
             <div id="button-container">
                 <div>
+                    <label style="color: white; font-size: 12px; display: block; margin-bottom: 5px;">Supported formats: GLB and STL files only</label>
                     <input type="file" id="model-file-input" accept=".glb,.stl" style="display: none" />
                     <button class="custom-button" id="model-load-button">Load model</button>
                 </div>


### PR DESCRIPTION
Add a label above the "Load model" button to indicate supported GLB and STL file formats.

---
<a href="https://cursor.com/background-agent?bcId=bc-b8093a82-a5a3-4b37-a833-65bdc001f8bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b8093a82-a5a3-4b37-a833-65bdc001f8bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>

┆Issue is synchronized with this [Notion page](https://www.notion.so/7-Add-file-type-support-label-261e0d23ae3481b4847eeac8704702e9) by [Unito](https://www.unito.io)
