### PR TITLE
Add usdz model loading and export options

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,8 +23,8 @@
             </div>
             <div id="button-container">
                 <div>
-                    <label style="color: white; font-size: 12px; display: block; margin-bottom: 5px;">Supported formats: GLB and STL files only</label>
-                    <input type="file" id="model-file-input" accept=".glb,.stl" style="display: none" />
+                    <label style="color: white; font-size: 12px; display: block; margin-bottom: 5px;">Supported formats: GLB, STL and USDZ files</label>
+                    <input type="file" id="model-file-input" accept=".glb,.stl,.usdz" style="display: none" />
                     <button class="custom-button" id="model-load-button">Load model</button>
                 </div>
                 <div>

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three'
 import {GLTFLoader} from 'three/addons/loaders/GLTFLoader.js'
 import {STLLoader} from 'three/addons/loaders/STLLoader.js'
+import {USDZLoader} from 'three/addons/loaders/USDZLoader.js'
 import {OrbitControls} from 'three/addons/controls/OrbitControls.js'
 // Import exporters
 import {GLTFExporter} from 'three/addons/exporters/GLTFExporter.js'
@@ -105,6 +106,35 @@ function loadSTLFile(event) {
     reader.readAsArrayBuffer(file)
   }
 
+//USDZ Loader
+function loadUSDZFile(event) {
+    const file = event.target.files[0];
+  
+    const reader = new FileReader()
+    reader.onload = function () {
+        const data = reader.result
+  
+        const usdzLoader = new USDZLoader()
+        usdzLoader.parse(data, function (usdzModel) {
+            // Only append renderer if it's not already in the container
+            if (!viewerContainer.contains(renderer.domElement)) {
+                viewerContainer.appendChild(renderer.domElement)
+            }
+            
+            models.push(usdzModel)
+            scene.add(usdzModel)
+
+            // Update conversion state
+            updateConversionState('usdz', usdzModel)
+
+            console.log("USDZ Model added")
+            animate()
+        })
+    }
+  
+    reader.readAsArrayBuffer(file)
+  }
+
 //Unified model loader - detects file type and calls appropriate loader
 function loadModelFile(event) {
     console.log('loadModelFile called', event)
@@ -123,9 +153,12 @@ function loadModelFile(event) {
     } else if (fileName.endsWith('.stl')) {
         console.log('Loading STL file')
         loadSTLFile(event);
+    } else if (fileName.endsWith('.usdz')) {
+        console.log('Loading USDZ file')
+        loadUSDZFile(event);
     } else {
-        console.error('Unsupported file type. Please select a GLB or STL file.');
-        alert('Unsupported file type. Please select a GLB or STL file.');
+        console.error('Unsupported file type. Please select a GLB, STL, or USDZ file.');
+        alert('Unsupported file type. Please select a GLB, STL, or USDZ file.');
     }
 }
 
@@ -213,6 +246,13 @@ const formatMappings = {
         { value: 'ply', label: 'PLY (.ply)' },
         { value: 'glb', label: 'GLB (.glb)' },
         { value: 'usdz', label: 'USDZ (.usdz)' }
+    ],
+    'usdz': [
+        { value: 'glb', label: 'GLB (.glb)' },
+        { value: 'gltf', label: 'GLTF (.gltf)' },
+        { value: 'obj', label: 'OBJ (.obj)' },
+        { value: 'ply', label: 'PLY (.ply)' },
+        { value: 'stl', label: 'STL (.stl)' }
     ]
 }
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add USDZ file loading support and enable export to GLB, GLTF, OBJ, PLY, and STL formats for loaded USDZ models.

---
<a href="https://cursor.com/background-agent?bcId=bc-fd305325-e8fb-4a79-a7a8-0313f847b691">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fd305325-e8fb-4a79-a7a8-0313f847b691">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>

┆Issue is synchronized with this [Notion page](https://www.notion.so/8-Add-usdz-model-loading-and-export-options-261e0d23ae3481419799de8b839e8834) by [Unito](https://www.unito.io)
