### PR TITLE
Fix usdz model loading bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,8 +114,10 @@ function loadUSDZFile(event) {
     reader.onload = function () {
         const data = reader.result
   
-        const usdzLoader = new USDZLoader()
-        usdzLoader.parse(data, function (usdzModel) {
+        try {
+            const usdzLoader = new USDZLoader()
+            const usdzModel = usdzLoader.parse(data)
+            
             // Only append renderer if it's not already in the container
             if (!viewerContainer.contains(renderer.domElement)) {
                 viewerContainer.appendChild(renderer.domElement)
@@ -127,9 +129,12 @@ function loadUSDZFile(event) {
             // Update conversion state
             updateConversionState('usdz', usdzModel)
 
-            console.log("USDZ Model added")
+            console.log("USDZ Model added successfully")
             animate()
-        })
+        } catch (error) {
+            console.error("Error loading USDZ file:", error)
+            alert('Error loading USDZ file. Please check the console for details.')
+        }
     }
   
     reader.readAsArrayBuffer(file)


### PR DESCRIPTION
Fix USDZ file loading by correcting `USDZLoader.parse()` usage and adding error handling.

The previous implementation incorrectly used `USDZLoader.parse()` with a callback function, which is not how the method operates. `USDZLoader.parse()` directly returns the parsed model. This PR updates the code to correctly capture the returned model and adds a `try-catch` block for robust error handling during the parsing process.

---
<a href="https://cursor.com/background-agent?bcId=bc-32cb3345-faa5-426a-8eda-0a1fac7e2fa2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-32cb3345-faa5-426a-8eda-0a1fac7e2fa2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>

┆Issue is synchronized with this [Notion page](https://www.notion.so/9-Fix-usdz-model-loading-bug-261e0d23ae3481738a7defb03cbf9506) by [Unito](https://www.unito.io)
