### PR TITLE
Add default grid on xz plane

### DIFF
--- a/js/SceneManager.js
+++ b/js/SceneManager.js
@@ -10,6 +10,7 @@ export class SceneManager {
         this.initCamera()
         this.initRenderer()
         this.initLighting()
+        this.initGrid()
         this.initControls()
         this.setupEventListeners()
         
@@ -66,6 +67,14 @@ export class SceneManager {
         lightUnder.position.set(0, 0, -5)
         lightUnder.lookAt(0, 0, 0)
         this.scene.add(lightUnder)
+    }
+    
+    initGrid() {
+        // Create a grid helper on the XZ plane at y=0
+        // Parameters: size, divisions, centerLineColor, gridColor
+        const gridHelper = new THREE.GridHelper(10, 10, 0x444444, 0x222222)
+        gridHelper.position.y = 0 // Ensure it's at y=0
+        this.scene.add(gridHelper)
     }
     
     initControls() {


### PR DESCRIPTION
Add a default `THREE.GridHelper` to the scene to provide a visual reference on the XZ plane at y=0.

---
<a href="https://cursor.com/background-agent?bcId=bc-a72579ef-ab7c-45f5-875c-44845bb8e0eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a72579ef-ab7c-45f5-875c-44845bb8e0eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>

┆Issue is synchronized with this [Notion page](https://www.notion.so/13-Add-default-grid-on-xz-plane-261e0d23ae348101b726f4f1d23b36a9) by [Unito](https://www.unito.io)
