### PR TITLE
Extend grid to infinite

### DIFF
--- a/js/InfiniteGrid.js
+++ b/js/InfiniteGrid.js
@@ -1,0 +1,124 @@
+import * as THREE from 'three'
+
+export class InfiniteGrid {
+    constructor(color1 = 0x444444, color2 = 0x222222, size = 10) {
+        this.color1 = new THREE.Color(color1)
+        this.color2 = new THREE.Color(color2)
+        this.size = size
+        
+        this.createGrid()
+    }
+    
+    createGrid() {
+        // Create a large plane geometry
+        const geometry = new THREE.PlaneGeometry(1000, 1000, 1, 1)
+        
+        // Custom shader material for infinite grid
+        const material = new THREE.ShaderMaterial({
+            uniforms: {
+                color1: { value: this.color1 },
+                color2: { value: this.color2 },
+                size: { value: this.size },
+                cameraPosition: { value: new THREE.Vector3() }
+            },
+            vertexShader: `
+                varying vec3 worldPosition;
+                varying vec3 localPosition;
+                
+                void main() {
+                    localPosition = position;
+                    vec4 worldPos = modelMatrix * vec4(position, 1.0);
+                    worldPosition = worldPos.xyz;
+                    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+                }
+            `,
+            fragmentShader: `
+                uniform vec3 color1;
+                uniform vec3 color2;
+                uniform float size;
+                uniform vec3 cameraPosition;
+                
+                varying vec3 worldPosition;
+                varying vec3 localPosition;
+                
+                float getGrid(vec2 coord, float gridSize) {
+                    vec2 derivative = fwidth(coord / gridSize);
+                    vec2 grid = abs(fract(coord / gridSize - 0.5) - 0.5) / derivative;
+                    float line = min(grid.x, grid.y);
+                    return 1.0 - min(line, 1.0);
+                }
+                
+                void main() {
+                    // Calculate distance from camera for fade effect
+                    float dist = length(worldPosition - cameraPosition);
+                    float fade = 1.0 - smoothstep(50.0, 150.0, dist);
+                    
+                    // Use world position for consistent grid across the infinite plane
+                    vec2 coord = worldPosition.xz;
+                    
+                    // Create main grid
+                    float grid1 = getGrid(coord, size);
+                    
+                    // Create finer grid (only show when close)
+                    float grid2 = getGrid(coord, size / 10.0);
+                    float closeFade = 1.0 - smoothstep(10.0, 30.0, dist);
+                    grid2 *= closeFade;
+                    
+                    // Combine grids
+                    vec3 finalColor = mix(color2, color1, grid1);
+                    finalColor = mix(finalColor, color1 * 0.7, grid2 * 0.5);
+                    
+                    // Apply fade based on distance
+                    float alpha = (grid1 + grid2 * 0.5) * fade;
+                    
+                    // Ensure some visibility even at distance for major grid lines
+                    alpha = max(alpha, grid1 * 0.15 * fade);
+                    
+                    gl_FragColor = vec4(finalColor, alpha);
+                }
+            `,
+            transparent: true,
+            side: THREE.DoubleSide,
+            depthWrite: false
+        })
+        
+        // Create the mesh
+        this.mesh = new THREE.Mesh(geometry, material)
+        this.mesh.rotation.x = -Math.PI / 2 // Rotate to be horizontal
+        this.mesh.position.y = 0
+        
+        // Make sure it renders behind other objects
+        this.mesh.renderOrder = -1
+    }
+    
+    updateCameraPosition(camera) {
+        // Update the camera position uniform for distance-based fading
+        this.mesh.material.uniforms.cameraPosition.value.copy(camera.position)
+        
+        // Move the grid to follow the camera (snapped to grid intervals)
+        const snapSize = this.size * 10
+        this.mesh.position.x = Math.floor(camera.position.x / snapSize) * snapSize
+        this.mesh.position.z = Math.floor(camera.position.z / snapSize) * snapSize
+    }
+    
+    setColors(color1, color2) {
+        this.color1.set(color1)
+        this.color2.set(color2)
+        this.mesh.material.uniforms.color1.value.copy(this.color1)
+        this.mesh.material.uniforms.color2.value.copy(this.color2)
+    }
+    
+    setSize(size) {
+        this.size = size
+        this.mesh.material.uniforms.size.value = size
+    }
+    
+    dispose() {
+        this.mesh.geometry.dispose()
+        this.mesh.material.dispose()
+    }
+    
+    get object3d() {
+        return this.mesh
+    }
+}

--- a/js/SceneManager.js
+++ b/js/SceneManager.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three'
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js'
+import { InfiniteGrid } from './InfiniteGrid.js'
 
 export class SceneManager {
     constructor(canvas) {
@@ -70,11 +71,9 @@ export class SceneManager {
     }
     
     initGrid() {
-        // Create a grid helper on the XZ plane at y=0
-        // Parameters: size, divisions, centerLineColor, gridColor
-        const gridHelper = new THREE.GridHelper(10, 10, 0x444444, 0x222222)
-        gridHelper.position.y = 0 // Ensure it's at y=0
-        this.scene.add(gridHelper)
+        // Create an infinite grid that extends in all directions
+        this.infiniteGrid = new InfiniteGrid(0x444444, 0x222222, 1)
+        this.scene.add(this.infiniteGrid.object3d)
     }
     
     initControls() {
@@ -99,6 +98,14 @@ export class SceneManager {
             this.scene.remove(this.models[i])
         }
         this.models.length = 0
+    }
+    
+    dispose() {
+        if (this.infiniteGrid) {
+            this.scene.remove(this.infiniteGrid.object3d)
+            this.infiniteGrid.dispose()
+            this.infiniteGrid = null
+        }
     }
     
         getModels() {
@@ -161,6 +168,12 @@ export class SceneManager {
     
     animate() {
         requestAnimationFrame(this.animate.bind(this))
+        
+        // Update infinite grid with camera position for proper rendering
+        if (this.infiniteGrid) {
+            this.infiniteGrid.updateCameraPosition(this.camera)
+        }
+        
         this.renderer.render(this.scene, this.camera)
     }
     


### PR DESCRIPTION
Implement a shader-based infinite grid to replace the finite GridHelper, providing an unlimited 3D workspace.

---
<a href="https://cursor.com/background-agent?bcId=bc-8773344d-aa2e-439f-8d5b-9c3802bec20d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8773344d-aa2e-439f-8d5b-9c3802bec20d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>

┆Issue is synchronized with this [Notion page](https://www.notion.so/14-Extend-grid-to-infinite-261e0d23ae348126b3f3c2d684829315) by [Unito](https://www.unito.io)
