### PR TITLE
Remove export restrictions by original file type

### DIFF
--- a/js/ModelConverter.js
+++ b/js/ModelConverter.js
@@ -15,32 +15,20 @@ export class ModelConverter {
             usdz: new USDZExporter()
         }
         
-        this.formatMappings = {
-            'glb': [
-                { value: 'obj', label: 'OBJ (.obj)' },
-                { value: 'ply', label: 'PLY (.ply)' },
-                { value: 'stl', label: 'STL (.stl)' },
-                { value: 'usdz', label: 'USDZ (.usdz)' },
-                { value: 'gltf', label: 'GLTF (.gltf)' }
-            ],
-            'stl': [
-                { value: 'obj', label: 'OBJ (.obj)' },
-                { value: 'ply', label: 'PLY (.ply)' },
-                { value: 'glb', label: 'GLB (.glb)' },
-                { value: 'usdz', label: 'USDZ (.usdz)' }
-            ],
-            'usdz': [
-                { value: 'glb', label: 'GLB (.glb)' },
-                { value: 'gltf', label: 'GLTF (.gltf)' },
-                { value: 'obj', label: 'OBJ (.obj)' },
-                { value: 'ply', label: 'PLY (.ply)' },
-                { value: 'stl', label: 'STL (.stl)' }
-            ]
-        }
+        // Universal format list - all formats available regardless of source file type
+        this.supportedFormats = [
+            { value: 'glb', label: 'GLB (.glb)' },
+            { value: 'gltf', label: 'GLTF (.gltf)' },
+            { value: 'obj', label: 'OBJ (.obj)' },
+            { value: 'ply', label: 'PLY (.ply)' },
+            { value: 'stl', label: 'STL (.stl)' },
+            { value: 'usdz', label: 'USDZ (.usdz)' }
+        ]
     }
     
     getSupportedFormats(sourceFormat) {
-        return this.formatMappings[sourceFormat] || []
+        // Return all supported formats regardless of source file type
+        return this.supportedFormats
     }
     
     async exportModel(model, format) {


### PR DESCRIPTION
Remove export restrictions in the export dropdown menu to allow users to export to any supported format regardless of the original model file type.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6808ed7-e202-4721-8a35-761771fb93ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a6808ed7-e202-4721-8a35-761771fb93ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>

┆Issue is synchronized with this [Notion page](https://www.notion.so/18-Remove-export-restrictions-by-original-file-type-261e0d23ae34811a869bf93d60eaf2a3) by [Unito](https://www.unito.io)
