### PR TITLE
Fix button availability when not processing

### DIFF
--- a/main.css
+++ b/main.css
@@ -54,23 +54,18 @@
 }
 
 /* Block all interactions when loading overlay is visible */
-#loading-overlay ~ * {
+#loading-overlay[style*="display: flex"] ~ * {
     pointer-events: none !important;
+    user-select: none !important;
 }
 
-/* Ensure button container can't be interacted with when loading overlay is shown */
+/* Ensure button container can't be interacted with when processing */
 body.processing #button-container {
     pointer-events: none;
 }
 
 body.processing * {
     cursor: not-allowed !important;
-}
-
-/* Additional safeguard: when loading overlay is displayed, block everything below it */
-#loading-overlay[style*="display: flex"] ~ * {
-    pointer-events: none !important;
-    user-select: none !important;
 }
 
 #loading-spinner-container {


### PR DESCRIPTION
Fixes buttons being unavailable when the loading overlay is hidden due to an overly broad CSS selector.

The original CSS rule `#loading-overlay ~ *` applied `pointer-events: none` to all sibling elements of the loading overlay, regardless of its `display` style. This meant buttons remained disabled even when the overlay was hidden with `display: none`. The fix modifies the selector to only apply when the loading overlay has `display: flex`, ensuring buttons are only disabled when the overlay is actively visible.

---
<a href="https://cursor.com/background-agent?bcId=bc-67a9bf14-e964-4925-8d3c-2bec0d02441c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-67a9bf14-e964-4925-8d3c-2bec0d02441c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

┆Issue is synchronized with this [Notion page](https://www.notion.so/21-Fix-button-availability-when-not-processing-261e0d23ae3481a78515f8bdf74eadf3) by [Unito](https://www.unito.io)
