### PR TITLE
Append models to scene, do not replace

### DIFF
--- a/js/UIManager.js
+++ b/js/UIManager.js
@@ -119,9 +119,6 @@ export class UIManager {
         
         console.log(`Loading ${files.length} file(s)...`)
         
-        // Clear existing models before loading new ones
-        this.handleClearModels()
-        
         // Track loading results
         const results = {
             successful: 0,


### PR DESCRIPTION
Remove `this.handleClearModels()` call to allow "Load models" to add models to the scene instead of replacing them.

---
<a href="https://cursor.com/background-agent?bcId=bc-b91c8411-426e-4da1-b5b6-0753fc5cd16d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b91c8411-426e-4da1-b5b6-0753fc5cd16d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

┆Issue is synchronized with this [Notion page](https://www.notion.so/23-Append-models-to-scene-do-not-replace-261e0d23ae34811ea3e6f75193be1234) by [Unito](https://www.unito.io)
