### PR TITLE
Reset models to origin on load

### DIFF
--- a/js/ModelLoaders.js
+++ b/js/ModelLoaders.js
@@ -12,21 +12,6 @@ export class ModelLoaders {
         this.loadedModelsCount = 0  // Track number of models loaded in current session
     }
     
-    // Calculate position for model based on index to arrange in a grid
-    calculateModelPosition(modelIndex) {
-        const spacing = 5  // Space between models
-        const modelsPerRow = 3  // Number of models per row
-        
-        const row = Math.floor(modelIndex / modelsPerRow)
-        const col = modelIndex % modelsPerRow
-        
-        return {
-            x: (col - 1) * spacing,  // Center the grid around origin
-            y: 0,
-            z: row * spacing
-        }
-    }
-    
     // Reset the loaded models counter (call when clearing models)
     resetLoadedModelsCount() {
         this.loadedModelsCount = 0
@@ -69,9 +54,8 @@ export class ModelLoaders {
                 try {
                     const glbModel = glb.scene
                     
-                    // Apply position based on load order
-                    const position = this.calculateModelPosition(this.loadedModelsCount)
-                    glbModel.position.set(position.x, position.y, position.z)
+                    // Position model at origin (0,0,0)
+                    glbModel.position.set(0, 0, 0)
                     this.loadedModelsCount++
                     
                     this.sceneManager.addModel(glbModel)
@@ -115,9 +99,8 @@ export class ModelLoaders {
                 // Pivot 90 degrees around the X axis
                 stlModel.rotateX(-Math.PI / 2)
                 
-                // Apply position based on load order
-                const position = this.calculateModelPosition(this.loadedModelsCount)
-                stlModel.position.set(position.x, position.y, position.z)
+                // Position model at origin (0,0,0)
+                stlModel.position.set(0, 0, 0)
                 this.loadedModelsCount++
                 
                 this.sceneManager.addModel(stlModel)
@@ -144,9 +127,8 @@ export class ModelLoaders {
                 const data = reader.result
                 const usdzModel = this.usdzLoader.parse(data)
                 
-                // Apply position based on load order
-                const position = this.calculateModelPosition(this.loadedModelsCount)
-                usdzModel.position.set(position.x, position.y, position.z)
+                // Position model at origin (0,0,0)
+                usdzModel.position.set(0, 0, 0)
                 this.loadedModelsCount++
                 
                 this.sceneManager.addModel(usdzModel)


### PR DESCRIPTION
Position all loaded models at (0,0,0) to meet the requirement for models to load at the scene origin.

---
<a href="https://cursor.com/background-agent?bcId=bc-a225c351-396e-4237-8c4b-6e618706c131">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a225c351-396e-4237-8c4b-6e618706c131">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

┆Issue is synchronized with this [Notion page](https://www.notion.so/25-Reset-models-to-origin-on-load-261e0d23ae3481619e1ed277c7d1c40a) by [Unito](https://www.unito.io)
