### PR TITLE
Display scene model tree with file types

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,11 @@
                         <span id="conversion-status" style="color: white; font-size: 12px; margin-left: 10px;"></span>
                     </div>
                 </div>
+                <!-- Model tree section -->
+                <div id="model-tree-container" style="display: none;">
+                    <div id="model-tree-title">Scene composition</div>
+                    <div id="model-tree-content"></div>
+                </div>
             </div>
         </div>
         <canvas class = "webgl"></canvas>

--- a/js/ModelLoaders.js
+++ b/js/ModelLoaders.js
@@ -54,11 +54,20 @@ export class ModelLoaders {
                 try {
                     const glbModel = glb.scene
                     
-                    // Position model at origin (0,0,0)
-                    glbModel.position.set(0, 0, 0)
+                    // Position model based on loaded models count
+                    const xOffset = this.loadedModelsCount * 2  // 2 units spacing between models
+                    glbModel.position.set(xOffset, 0, 0)
                     this.loadedModelsCount++
                     
-                    this.sceneManager.addModel(glbModel)
+                    // Add model to scene with metadata
+                    const metadata = {
+                        filename: file.name,
+                        fileType: 'GLB',
+                        originalFile: file
+                    }
+                    this.sceneManager.addModel(glbModel, metadata)
+                    this.sceneManager.recenterCameraOnAllModels()
+                    
                     console.log('GLB model loaded successfully')
                     resolve({ model: glbModel, fileType: 'glb' })
                 } catch (error) {
@@ -99,17 +108,22 @@ export class ModelLoaders {
                 // Pivot 90 degrees around the X axis
                 stlModel.rotateX(-Math.PI / 2)
                 
-                // Position model at origin (0,0,0)
-                stlModel.position.set(0, 0, 0)
+                // Position model based on loaded models count
+                const xOffset = this.loadedModelsCount * 2  // 2 units spacing between models
+                stlModel.position.set(xOffset, 0, 0)
                 this.loadedModelsCount++
                 
-                this.sceneManager.addModel(stlModel)
+                // Add model to scene with metadata
+                const metadata = {
+                    filename: file.name,
+                    fileType: 'STL',
+                    originalFile: file
+                }
+                this.sceneManager.addModel(stlModel, metadata)
+                this.sceneManager.recenterCameraOnAllModels()
                 
-                console.log("STL Model added")
-                resolve({
-                    model: stlModel,
-                    fileType: 'stl'
-                })
+                console.log('STL model loaded successfully')
+                resolve({ model: stlModel, fileType: 'stl' })
             } catch (error) {
                 reject(error)
             }
@@ -127,17 +141,22 @@ export class ModelLoaders {
                 const data = reader.result
                 const usdzModel = this.usdzLoader.parse(data)
                 
-                // Position model at origin (0,0,0)
-                usdzModel.position.set(0, 0, 0)
+                // Position model based on loaded models count
+                const xOffset = this.loadedModelsCount * 2  // 2 units spacing between models
+                usdzModel.position.set(xOffset, 0, 0)
                 this.loadedModelsCount++
                 
-                this.sceneManager.addModel(usdzModel)
+                // Add model to scene with metadata
+                const metadata = {
+                    filename: file.name,
+                    fileType: 'USDZ',
+                    originalFile: file
+                }
+                this.sceneManager.addModel(usdzModel, metadata)
+                this.sceneManager.recenterCameraOnAllModels()
                 
-                console.log("USDZ Model added successfully")
-                resolve({
-                    model: usdzModel,
-                    fileType: 'usdz'
-                })
+                console.log('USDZ model loaded successfully')
+                resolve({ model: usdzModel, fileType: 'usdz' })
             } catch (error) {
                 console.error("Error loading USDZ file:", error)
                 reject(error)

--- a/js/SceneManager.js
+++ b/js/SceneManager.js
@@ -6,6 +6,7 @@ export class SceneManager {
         console.log('SceneManager constructor called with canvas:', canvas)
         this.canvas = canvas
         this.models = []
+        this.modelMetadata = [] // Store metadata for each model
         this.animationFrame = 0
         
         this.initScene()
@@ -120,8 +121,9 @@ export class SceneManager {
         window.addEventListener('resize', this.onWindowResize.bind(this), false)
     }
     
-    addModel(model) {
+    addModel(model, fileMetadata = {}) {
         this.models.push(model)
+        this.modelMetadata.push(fileMetadata)
         this.scene.add(model)
     }
     
@@ -130,6 +132,7 @@ export class SceneManager {
             this.scene.remove(this.models[i])
         }
         this.models.length = 0
+        this.modelMetadata.length = 0
     }
     
     dispose() {
@@ -138,6 +141,10 @@ export class SceneManager {
     
     getModels() {
         return this.models
+    }
+    
+    getModelMetadata() {
+        return this.modelMetadata
     }
 
     getCurrentModel() {

--- a/js/UIManager.js
+++ b/js/UIManager.js
@@ -42,6 +42,10 @@ export class UIManager {
         this.elements.convertButton = document.getElementById('convert-button')
         this.elements.conversionStatus = document.getElementById('conversion-status')
         
+        // Model tree UI elements
+        this.elements.modelTreeContainer = document.getElementById('model-tree-container')
+        this.elements.modelTreeContent = document.getElementById('model-tree-content')
+        
         this.validateUIElements()
     }
     
@@ -160,6 +164,9 @@ export class UIManager {
                 // Recenter camera to show all loaded models
                 this.sceneManager.recenterCameraOnAllModels()
                 
+                // Update the model tree
+                this.updateModelTree()
+                
                 // Update status message
                 let message = `Successfully loaded ${results.successful} model${results.successful > 1 ? 's' : ''}`
                 if (results.failed > 0) {
@@ -198,6 +205,9 @@ export class UIManager {
         // Ensure viewer container has the renderer
         this.setupViewerContainer()
         
+        // Update the model tree
+        this.updateModelTree()
+        
         console.log(`${fileType.toUpperCase()} Model loaded successfully`)
     }
     
@@ -207,6 +217,9 @@ export class UIManager {
         this.currentModel = null
         this.currentLoadedFileType = null
         this.hideConversionSection()
+        
+        // Update the model tree (will hide it since no models)
+        this.updateModelTree()
         
         console.log("Models cleared")
     }
@@ -317,6 +330,51 @@ export class UIManager {
         if (this.elements.conversionStatus) {
             this.elements.conversionStatus.textContent = message
         }
+    }
+    
+    updateModelTree() {
+        const models = this.sceneManager.getModels()
+        const metadata = this.sceneManager.getModelMetadata()
+        
+        if (!this.elements.modelTreeContainer || !this.elements.modelTreeContent) {
+            return
+        }
+        
+        // Show/hide the model tree based on whether models are loaded
+        if (models.length === 0) {
+            this.elements.modelTreeContainer.style.display = 'none'
+            return
+        }
+        
+        this.elements.modelTreeContainer.style.display = 'block'
+        
+        // Clear existing content
+        this.elements.modelTreeContent.innerHTML = ''
+        
+        // Add each model to the tree
+        metadata.forEach((meta, index) => {
+            const item = document.createElement('div')
+            item.className = 'model-tree-item'
+            
+            // Extract filename without extension
+            const filename = meta.filename || 'Unnamed Model'
+            const nameWithoutExtension = filename.substring(0, filename.lastIndexOf('.')) || filename
+            
+            // Create model name element
+            const nameElement = document.createElement('div')
+            nameElement.className = 'model-name'
+            nameElement.textContent = nameWithoutExtension
+            
+            // Create file type tag
+            const tagElement = document.createElement('div')
+            tagElement.className = `file-type-tag ${meta.fileType.toLowerCase()}`
+            tagElement.textContent = meta.fileType
+            
+            item.appendChild(nameElement)
+            item.appendChild(tagElement)
+            
+            this.elements.modelTreeContent.appendChild(item)
+        })
     }
     
     showLoadingState(message = 'Loading models...') {

--- a/main.css
+++ b/main.css
@@ -36,3 +36,66 @@
 #conversion-status {
     font-style: italic;
 }
+
+/* Model Tree Styles */
+#model-tree-container {
+    width: 300px;
+    min-height: 35px;
+    max-height: 530px;
+    background-color: #333333;
+    border: 1px solid #555555;
+    border-radius: 5px;
+    padding: 10px;
+    margin-top: 10px;
+    overflow-y: auto;
+}
+
+#model-tree-title {
+    font-size: 13px;
+    color: #F5F5F5;
+    margin-bottom: 8px;
+}
+
+#model-tree-content {
+    font-size: 13px;
+    color: #F5F5F5;
+}
+
+.model-tree-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 4px 0;
+}
+
+.model-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    margin-right: 10px;
+}
+
+.file-type-tag {
+    height: 14px;
+    line-height: 14px;
+    padding: 0 6px;
+    border-radius: 2px;
+    font-size: 10px;
+    color: #F5F5F5;
+    display: inline-block;
+    text-align: center;
+    white-space: nowrap;
+}
+
+.file-type-tag.glb {
+    background-color: #0011C8;
+}
+
+.file-type-tag.stl {
+    background-color: #007315;
+}
+
+.file-type-tag.usdz {
+    background-color: #BA5D00;
+}


### PR DESCRIPTION
Adds a model tree to display loaded scene models with their file types for better scene composition overview.

---
<a href="https://cursor.com/background-agent?bcId=bc-c8a53377-147a-4c77-a702-90c20ff80203">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c8a53377-147a-4c77-a702-90c20ff80203">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

┆Issue is synchronized with this [Notion page](https://www.notion.so/26-Display-scene-model-tree-with-file-types-261e0d23ae348140bdeeee6de94fa456) by [Unito](https://www.unito.io)
