### PR TITLE
Add delete button to model tree

### DIFF
--- a/js/SceneManager.js
+++ b/js/SceneManager.js
@@ -135,6 +135,21 @@ export class SceneManager {
         this.modelMetadata.length = 0
     }
     
+    removeModel(index) {
+        if (index >= 0 && index < this.models.length) {
+            // Remove model from scene
+            this.scene.remove(this.models[index])
+            
+            // Remove from arrays
+            this.models.splice(index, 1)
+            this.modelMetadata.splice(index, 1)
+            
+            console.log(`Model at index ${index} removed from scene`)
+            return true
+        }
+        return false
+    }
+    
     dispose() {
         // No special disposal needed for GridHelper since it uses standard Three.js objects
     }

--- a/js/UIManager.js
+++ b/js/UIManager.js
@@ -365,16 +365,47 @@ export class UIManager {
             nameElement.className = 'model-name'
             nameElement.textContent = nameWithoutExtension
             
+            // Create delete button with trash icon
+            const deleteButton = document.createElement('button')
+            deleteButton.className = 'delete-button'
+            deleteButton.setAttribute('data-index', index)
+            deleteButton.innerHTML = `
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M3 6h18M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2m3 0v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6h14zM10 11v6M14 11v6" 
+                          stroke="#818181" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            `
+            deleteButton.addEventListener('click', () => this.handleRemoveModel(index))
+            
             // Create file type tag
             const tagElement = document.createElement('div')
             tagElement.className = `file-type-tag ${meta.fileType.toLowerCase()}`
             tagElement.textContent = meta.fileType
             
             item.appendChild(nameElement)
+            item.appendChild(deleteButton)
             item.appendChild(tagElement)
             
             this.elements.modelTreeContent.appendChild(item)
         })
+    }
+    
+    handleRemoveModel(index) {
+        // Remove the model from the scene
+        const removed = this.sceneManager.removeModel(index)
+        
+        if (removed) {
+            // Update the model tree
+            this.updateModelTree()
+            
+            // Update conversion section visibility
+            const models = this.sceneManager.getModels()
+            if (models.length === 0) {
+                this.hideConversionSection()
+                this.currentLoadedFileType = null
+                this.currentModel = null
+            }
+        }
     }
     
     showLoadingState(message = 'Loading models...') {

--- a/main.css
+++ b/main.css
@@ -76,6 +76,37 @@
     margin-right: 10px;
 }
 
+/* Delete button styles */
+.delete-button {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background-color: #818181;
+    border: 1px solid #989898;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-right: 8px;
+    padding: 0;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.2s ease, visibility 0.2s ease;
+}
+
+.model-tree-item:hover .delete-button {
+    opacity: 1;
+    visibility: visible;
+}
+
+.delete-button:hover {
+    background-color: #6a6a6a;
+}
+
+.delete-button svg {
+    pointer-events: none;
+}
+
 .file-type-tag {
     height: 14px;
     line-height: 14px;


### PR DESCRIPTION
Add a hover-activated delete button to model tree items to allow users to remove individual models from the scene.

---
<a href="https://cursor.com/background-agent?bcId=bc-f86ee5e0-6a91-42bd-b9bc-115404eca657">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f86ee5e0-6a91-42bd-b9bc-115404eca657">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

┆Issue is synchronized with this [Notion page](https://www.notion.so/27-Add-delete-button-to-model-tree-261e0d23ae34816d961dc2bfb0b107fa) by [Unito](https://www.unito.io)
