### PR TITLE
Fix model file type label visibility

### DIFF
--- a/main.css
+++ b/main.css
@@ -139,8 +139,7 @@
     border-radius: 3px;
 }
 
-.model-tree-item.selected .model-name,
-.model-tree-item.selected .file-type-tag {
+.model-tree-item.selected .model-name {
     background-color: transparent;
 }
 


### PR DESCRIPTION
Ensures model file type labels remain visible when selected by preventing their background from becoming transparent.

The previous CSS rule for selected model tree items incorrectly applied `background-color: transparent` to `.file-type-tag` elements. As these tags use colored backgrounds for visibility, making them transparent caused them to disappear when selected. This change removes `.file-type-tag` from that rule, allowing the labels to retain their colored backgrounds and remain visible.

---
<a href="https://cursor.com/background-agent?bcId=bc-801f0b91-58be-40e5-bb8f-31d68df6902f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-801f0b91-58be-40e5-bb8f-31d68df6902f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

┆Issue is synchronized with this [Notion page](https://www.notion.so/29-Fix-model-file-type-label-visibility-261e0d23ae348176af44e8629b7eadbe) by [Unito](https://www.unito.io)
