### PR TITLE
Deselect models on escape or click outside

### DIFF
--- a/main.css
+++ b/main.css
@@ -65,7 +65,23 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 4px 0;
+    padding: 6px 8px;
+    margin: 2px -8px;
+    cursor: pointer;
+    border-radius: 3px;
+    transition: background-color 0.2s ease;
+}
+
+.model-tree-item:hover {
+    background-color: #404040;
+}
+
+.model-tree-item.selected {
+    background-color: #2563eb;
+}
+
+.model-tree-item.selected:hover {
+    background-color: #1d4ed8;
 }
 
 .model-name {


### PR DESCRIPTION
Enables unselecting all models in the tree by clicking outside or pressing ESC, and introduces model selection functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-0020c5d9-9636-4932-a726-ec1e3ee1bfc2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0020c5d9-9636-4932-a726-ec1e3ee1bfc2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

┆Issue is synchronized with this [Notion page](https://www.notion.so/30-Deselect-models-on-escape-or-click-outside-261e0d23ae348106b008e326320483ad) by [Unito](https://www.unito.io)
