### PR TITLE
Allow quick unselection of models in tree

### DIFF
--- a/main.css
+++ b/main.css
@@ -66,6 +66,21 @@
     justify-content: space-between;
     align-items: center;
     padding: 4px 0;
+    border-radius: 3px;
+    transition: background-color 0.2s ease;
+}
+
+.model-tree-item.selected {
+    background-color: #444444;
+}
+
+/* Checkbox styles */
+.model-checkbox {
+    width: 14px;
+    height: 14px;
+    margin-right: 8px;
+    cursor: pointer;
+    accent-color: #0066cc;
 }
 
 .model-name {


### PR DESCRIPTION
Adds functionality to unselect all models in the model tree by clicking outside or pressing ESC, fixing a bug where quick unselection was not possible.

---
<a href="https://cursor.com/background-agent?bcId=bc-8c842d02-303f-4247-add2-e6b819da9dcd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8c842d02-303f-4247-add2-e6b819da9dcd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

┆Issue is synchronized with this [Notion page](https://www.notion.so/31-Allow-quick-unselection-of-models-in-tree-261e0d23ae3481208cf6f287e389465f) by [Unito](https://www.unito.io)
