### PR TITLE
Update model count display on load and delete

### DIFF
--- a/js/UIManager.js
+++ b/js/UIManager.js
@@ -171,6 +171,15 @@ export class UIManager {
                     // Update state for the last loaded model
                     this.currentModel = result.model
                     this.currentLoadedFileType = result.fileType
+                    
+                    // Show model tree and update title immediately after first successful load
+                    if (results.successful === 1) {
+                        const models = this.sceneManager.getModels()
+                        if (models.length > 0) {
+                            this.elements.modelTreeContainer.style.display = 'block'
+                            this.updateModelTreeTitle(models.length)
+                        }
+                    }
                 } catch (error) {
                     console.error(`Error loading file ${file.name}:`, error)
                     results.failed++
@@ -361,6 +370,17 @@ export class UIManager {
         }
     }
     
+    updateModelTreeTitle(modelCount) {
+        const titleElement = document.getElementById('model-tree-title')
+        if (titleElement) {
+            if (modelCount === 1) {
+                titleElement.textContent = '1 model loaded'
+            } else {
+                titleElement.textContent = `${modelCount} models loaded`
+            }
+        }
+    }
+    
     updateModelTree() {
         const models = this.sceneManager.getModels()
         const metadata = this.sceneManager.getModelMetadata()
@@ -376,6 +396,9 @@ export class UIManager {
         }
         
         this.elements.modelTreeContainer.style.display = 'block'
+        
+        // Update the model tree title with model count
+        this.updateModelTreeTitle(models.length)
         
         // Clear existing content
         this.elements.modelTreeContent.innerHTML = ''


### PR DESCRIPTION
Display dynamic model count in the scene composition title, updating on model load and deletion.

---
<a href="https://cursor.com/background-agent?bcId=bc-083c29ff-5169-486c-b0d0-65661df8dd33">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-083c29ff-5169-486c-b0d0-65661df8dd33">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

┆Issue is synchronized with this [Notion page](https://www.notion.so/35-Update-model-count-display-on-load-and-delete-261e0d23ae3481148efef396ddb13f59) by [Unito](https://www.unito.io)
