### PR TITLE
Remove info line next to create button

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,6 @@
                     </div>
                     <div>
                         <button class="custom-button" id="convert-button" disabled>Create</button>
-                        <span id="conversion-status" style="color: white; font-size: 12px; margin-left: 10px;"></span>
                     </div>
                 </div>
                 <!-- Model tree section -->

--- a/js/UIManager.js
+++ b/js/UIManager.js
@@ -44,7 +44,6 @@ export class UIManager {
         this.elements.conversionSection = document.getElementById('conversion-section')
         this.elements.formatSelector = document.getElementById('format-selector')
         this.elements.convertButton = document.getElementById('convert-button')
-        this.elements.conversionStatus = document.getElementById('conversion-status')
         
         // Model tree UI elements
         this.elements.modelTreeContainer = document.getElementById('model-tree-container')
@@ -55,7 +54,7 @@ export class UIManager {
     
     validateUIElements() {
         const mainElements = ['modelLoadButton', 'modelFileInput', 'clearButton', 'viewerContainer']
-        const conversionElements = ['conversionSection', 'formatSelector', 'convertButton', 'conversionStatus']
+        const conversionElements = ['conversionSection', 'formatSelector', 'convertButton']
         
         const missingMain = mainElements.filter(key => !this.elements[key])
         const missingConversion = conversionElements.filter(key => !this.elements[key])
@@ -275,39 +274,16 @@ export class UIManager {
         // Get all models from the scene for export
         const allModels = this.sceneManager.getAllModelsAsGroup()
         if (!allModels) {
-            this.updateConversionStatus('No models to export!')
-            setTimeout(() => this.updateConversionStatus(''), 3000)
             return
         }
         
         this.elements.convertButton.disabled = true
         const modelCount = this.sceneManager.getModels().length
-        const statusPrefix = modelCount > 1 ? `Converting ${modelCount} models...` : 'Converting...'
-        this.updateConversionStatus(statusPrefix)
         
         try {
             await this.modelConverter.exportModel(allModels, selectedFormat)
-            const successMessage = modelCount > 1 ? `All ${modelCount} models exported successfully!` : 'Conversion completed!'
-            this.updateConversionStatus(successMessage)
-            setTimeout(() => {
-                // Reset to show model count if multiple models
-                if (modelCount > 1) {
-                    this.updateConversionStatus(`${modelCount} models loaded - all will be exported together`)
-                } else {
-                    this.updateConversionStatus('')
-                }
-            }, 3000)
         } catch (error) {
             console.error('Export error:', error)
-            this.updateConversionStatus('Export failed!')
-            setTimeout(() => {
-                // Reset to show model count if multiple models
-                if (modelCount > 1) {
-                    this.updateConversionStatus(`${modelCount} models loaded - all will be exported together`)
-                } else {
-                    this.updateConversionStatus('')
-                }
-            }, 3000)
         } finally {
             this.elements.convertButton.disabled = false
         }
@@ -343,13 +319,7 @@ export class UIManager {
         }
         this.elements.formatSelector.value = ''
         
-        // Update status to show how many models are loaded
-        const modelCount = this.sceneManager.getModels().length
-        if (modelCount > 1) {
-            this.updateConversionStatus(`${modelCount} models loaded - all will be exported together`)
-        } else {
-            this.updateConversionStatus('')
-        }
+        // Note: modelCount tracking removed along with status display
     }
     
     showConversionSection() {
@@ -361,12 +331,6 @@ export class UIManager {
     hideConversionSection() {
         if (this.elements.conversionSection) {
             this.elements.conversionSection.style.display = 'none'
-        }
-    }
-    
-    updateConversionStatus(message) {
-        if (this.elements.conversionStatus) {
-            this.elements.conversionStatus.textContent = message
         }
     }
     


### PR DESCRIPTION
Remove the conversion status display next to the 'Create' button and its associated JavaScript logic to simplify the UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-b4c6aaec-938a-485a-8ded-c3102e1c492e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b4c6aaec-938a-485a-8ded-c3102e1c492e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

┆Issue is synchronized with this [Notion page](https://www.notion.so/36-Remove-info-line-next-to-create-button-261e0d23ae34814fb30fddc437cdf01b) by [Unito](https://www.unito.io)
