### PR TITLE
Move export format and create button below model tree

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,11 @@
                 <div>
                     <button class="custom-button" id="clear-models">Clear models</button>
                 </div>
+                <!-- Model tree section -->
+                <div id="model-tree-container" style="display: none;">
+                    <div id="model-tree-title">Scene composition</div>
+                    <div id="model-tree-content"></div>
+                </div>
                 <!-- New conversion section -->
                 <div id="conversion-section" style="margin-top: 10px; display: none;">
                     <div style="margin-bottom: 5px;">
@@ -61,11 +66,6 @@
                     <div>
                         <button class="custom-button" id="convert-button" disabled>Create</button>
                     </div>
-                </div>
-                <!-- Model tree section -->
-                <div id="model-tree-container" style="display: none;">
-                    <div id="model-tree-title">Scene composition</div>
-                    <div id="model-tree-content"></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Move the 'Export Format' dropdown and 'Create' button below the model tree to align with the requested UI order.

---
<a href="https://cursor.com/background-agent?bcId=bc-638f44a4-875f-44b6-9645-f06c4c72bd90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-638f44a4-875f-44b6-9645-f06c4c72bd90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

┆Issue is synchronized with this [Notion page](https://www.notion.so/37-Move-export-format-and-create-button-below-model-tree-261e0d23ae348165a7e9f8061be7a103) by [Unito](https://www.unito.io)
