### PR TITLE
Fix file selection for iphone users

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The application exposes a global `app` object for programmatic access:
 // Load a model programmatically
 const fileInput = document.createElement('input');
 fileInput.type = 'file';
-fileInput.accept = '.glb,.stl,.usdz';
+fileInput.accept = 'model/gltf-binary,model/stl,model/vnd.usdz+zip,.glb,.stl,.usdz';
 fileInput.onchange = async (e) => {
     try {
         const result = await app.loadModel(e.target.files[0]);

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
             <div id="button-container">
                 <div>
                     <label style="color: white; font-size: 12px; display: block; margin-bottom: 5px;">Supported formats: GLB, STL and USDZ files</label>
-                    <input type="file" id="model-file-input" accept=".glb,.stl,.usdz" style="display: none" multiple />
+                    <input type="file" id="model-file-input" accept="model/gltf-binary,model/stl,model/vnd.usdz+zip,.glb,.stl,.usdz" style="display: none" multiple />
                     <button class="custom-button" id="model-load-button">Load models</button>
                 </div>
                 <div>


### PR DESCRIPTION
Add MIME types to file input `accept` attribute to enable file selection on iOS devices.

iOS Safari does not recognize file extensions in the `accept` attribute, preventing users from selecting files. Including the corresponding MIME types (`model/gltf-binary`, `model/stl`, `model/vnd.usdz+zip`) resolves this iOS-specific limitation while maintaining compatibility with other browsers.

---
<a href="https://cursor.com/background-agent?bcId=bc-12687d89-9a5a-4e13-8c6a-6d76d0b50fe1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-12687d89-9a5a-4e13-8c6a-6d76d0b50fe1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

┆Issue is synchronized with this [Notion page](https://www.notion.so/39-Fix-file-selection-for-iphone-users-261e0d23ae348166a0c0d5aa03a869ee) by [Unito](https://www.unito.io)
