### PR TITLE
Prevent tree deselection on outside click

### DIFF
--- a/js/UIManager.js
+++ b/js/UIManager.js
@@ -114,14 +114,6 @@ export class UIManager {
     }
     
     setupSelectionEventListeners() {
-        // Click outside to unselect all models
-        document.addEventListener('click', (e) => {
-            const modelTreeContainer = this.elements.modelTreeContainer
-            if (modelTreeContainer && !modelTreeContainer.contains(e.target)) {
-                this.unselectAllModels()
-            }
-        })
-        
         // ESC key to unselect all models
         document.addEventListener('keydown', (e) => {
             if (e.key === 'Escape') {


### PR DESCRIPTION
Remove document click listener to prevent accidental clearing of model selection when clicking outside the tree.

---
<a href="https://cursor.com/background-agent?bcId=bc-45e4f34f-2eda-4546-9eed-e66884b13d87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-45e4f34f-2eda-4546-9eed-e66884b13d87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

┆Issue is synchronized with this [Notion page](https://www.notion.so/40-Prevent-tree-deselection-on-outside-click-261e0d23ae3481ba8fdbd055515b039c) by [Unito](https://www.unito.io)
