### PR TITLE
Resize gizmo to one third size

### DIFF
--- a/js/SceneManager.js
+++ b/js/SceneManager.js
@@ -298,7 +298,7 @@ export class SceneManager {
         const cameraDistance = this.camera.position.distanceTo(modelWorldPosition)
         
         // Target screen size for the gizmo in pixels (adjust this value to change apparent size)
-        const targetScreenSizePixels = 80
+        const targetScreenSizePixels = 27
         
         // Calculate the world size needed to achieve the target screen size
         // This uses the perspective projection formula to convert screen pixels to world units


### PR DESCRIPTION
Reduce gizmo size to one-third of its original size to meet user specifications.

---
<a href="https://cursor.com/background-agent?bcId=bc-7612c72b-077f-47e9-a6fe-c819dfaf8663">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7612c72b-077f-47e9-a6fe-c819dfaf8663">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

┆Issue is synchronized with this [Notion page](https://www.notion.so/43-Resize-gizmo-to-one-third-size-261e0d23ae348126a6bfdd84d52391ab) by [Unito](https://www.unito.io)
